### PR TITLE
chore: use production n8n webhook

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,7 +770,7 @@
         // Configuration
         const VIEWER_URL = 'https://clovenbradshaw-ctrl.github.io/safety/';
         const BEACON_TEXT = 'SQR:1';
-        const WEBHOOK_URL = 'https://n8n.intelechia.com/webhook-test/d5e99c29-2cf1-44c1-b5b4-95a1ca048441';
+        const WEBHOOK_URL = 'https://n8n.intelechia.com/webhook/d5e99c29-2cf1-44c1-b5b4-95a1ca048441';
         const ARCHIVE_BASE = 'https://archive.org/download/zuboff/';
 
 


### PR DESCRIPTION
## Summary
- switch webhook URL to production n8n endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ad32a67df88332ba7cfa4e8df1b71f