### PR TITLE
Remove flag icons from language selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -777,9 +777,6 @@
             white-space: nowrap;
         }
 
-        .lang-flag {
-            font-size: 16px;
-        }
 
         .more-languages-btn {
             width: 40px;
@@ -868,19 +865,15 @@
         <div class="primary-languages">
             <button class="lang-btn active" data-lang="en">
                 <span class="lang-native">English</span>
-                <span class="lang-flag">🇺🇸</span>
             </button>
             <button class="lang-btn" data-lang="es">
                 <span class="lang-native">Español</span>
-                <span class="lang-flag">🇲🇽</span>
             </button>
             <button class="lang-btn" data-lang="ar">
                 <span class="lang-native">العربية</span>
-                <span class="lang-flag">🇸🇦</span>
             </button>
             <button class="lang-btn" data-lang="ku">
                 <span class="lang-native">کوردی</span>
-                <span class="lang-flag">🏳️</span>
             </button>
         </div>
 
@@ -892,27 +885,21 @@
         <div class="secondary-languages" style="display: none;">
             <button class="lang-btn" data-lang="vi">
                 <span class="lang-native">Tiếng Việt</span>
-                <span class="lang-flag">🇻🇳</span>
             </button>
             <button class="lang-btn" data-lang="zh">
                 <span class="lang-native">中文</span>
-                <span class="lang-flag">🇨🇳</span>
             </button>
             <button class="lang-btn" data-lang="so">
                 <span class="lang-native">Soomaali</span>
-                <span class="lang-flag">🇸🇴</span>
             </button>
             <button class="lang-btn" data-lang="my">
                 <span class="lang-native">မြန်မာ</span>
-                <span class="lang-flag">🇲🇲</span>
             </button>
             <button class="lang-btn" data-lang="ne">
                 <span class="lang-native">नेपाली</span>
-                <span class="lang-flag">🇳🇵</span>
             </button>
             <button class="lang-btn" data-lang="am">
                 <span class="lang-native">አማርኛ</span>
-                <span class="lang-flag">🇪🇹</span>
             </button>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Remove flag emojis from language selector and rely solely on language names.
- Drop styling for removed `.lang-flag` elements.

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_b_68ad369405608332bab58a05fc7e6b50