### PR TITLE
feat: remove duplicate owner password prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -1151,6 +1151,7 @@
         let currentCreated = null;
         let currentName = null;
         let securityInterval = null;
+        let ownerPassword = null;
 
         // Parse URL and handle QR modes
         async function parseUrlParameters() {
@@ -1498,6 +1499,7 @@
                 if (!currentBlob.privateInfo || hash !== currentBlob.privateInfo.encryptedWith) {
                     throw new Error('Incorrect password');
                 }
+                ownerPassword = password;
 
                 const privateInfo = currentBlob.privateInfo;
                 let html = '<div style="margin-top: 15px;">';
@@ -1538,13 +1540,15 @@
         }
 
         function ownerLogin() {
-            showUpdateForm();
+            const password = ownerPassword || document.getElementById('vault-password')?.value;
+            if (!password) {
+                alert('Please enter your password to update this emergency QR.');
+                return;
+            }
+            showUpdateForm(password);
         }
 
-        async function showUpdateForm() {
-            const password = prompt("Enter your password to update this emergency QR:");
-            if (!password) return;
-
+        async function showUpdateForm(password) {
             try {
                 // Generate update token
                 const updateToken = await generateUpdateToken(password, currentGUID);


### PR DESCRIPTION
## Summary
- avoid prompting for owner password twice by storing it after unlock
- reuse stored password for Owner Login and feed it into the update workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ad3a4e4ad48332a1e0bcd77c570492