### PR TITLE
Fix mobile menu overlapping banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,7 +544,8 @@
         /* Mobile Responsive */
         @media (max-width: 480px) {
             body {
-                padding: 10px;
+                /* Maintain space for fixed top menu */
+                padding: 60px 10px 10px;
             }
             
             .container {


### PR DESCRIPTION
## Summary
- Ensure mobile layout leaves space for fixed top menu to prevent overlapping with banner image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68addcf3af188332a0a65b798205f8ce