### PR TITLE
Fix language menu for RTL languages

### DIFF
--- a/index.html
+++ b/index.html
@@ -775,6 +775,7 @@
             padding: 6px 10px;
             cursor: pointer;
             font-size: 14px;
+            direction: ltr;
         }
 
         .lang-dropdown {
@@ -791,6 +792,8 @@
             overflow-y: auto;
             min-width: 160px;
             z-index: 1000;
+            direction: ltr;
+            text-align: left;
         }
 
         .lang-option {
@@ -963,6 +966,7 @@ body.rtl .info-icon {
           item.className = 'lang-option';
           item.dataset.lang = code;
           item.textContent = `${code.toUpperCase()} ${LANGUAGE_NAMES[code] || code}`;
+          item.setAttribute('dir', 'auto');
           item.addEventListener('click', () => {
             setLanguage(code);
             toggleLangDropdown(false);
@@ -985,6 +989,9 @@ body.rtl .info-icon {
         function setLanguage(langCode) {
           currentLanguage = langCode;
           localStorage.setItem('preferredLanguage', langCode);
+
+          document.documentElement.lang = langCode;
+          document.documentElement.dir = RTL_LANGS.includes(langCode) ? 'rtl' : 'ltr';
 
           const t = translations[langCode] || translations.en || {};
           document.querySelectorAll('[data-i18n]').forEach(el => {


### PR DESCRIPTION
## Summary
- Ensure language button and dropdown remain left-to-right for readability
- Auto-detect direction of language options
- Set document language and direction based on selected language

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ade0cebda88332859a4352ac814535