### PR TITLE
Add upload status polling and ETA messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -1035,7 +1035,9 @@ body.rtl .info-icon {
         let currentMode = null;
         let currentCreated = null;
         let currentName = null;
+        let currentCriticalInfo = null;
         let ownerPassword = null;
+        let uploadCheckInterval = null;
 
         async function parseAndDisplay() {
             const hash = window.location.hash.substring(1);
@@ -1056,11 +1058,14 @@ body.rtl .info-icon {
             currentKey = key;
             currentMode = 'view';
             const embedded = JSON.parse(atob(embeddedStr));
+            currentName = embedded.n;
+            currentCriticalInfo = embedded.c;
+            currentCreated = embedded.t || null;
 
             // Show embedded data immediately
             displayBasicInfo({
-                name: embedded.n,
-                criticalInfo: embedded.c
+                name: currentName,
+                criticalInfo: currentCriticalInfo
             });
 
             // Attempt to load full data (non-blocking)
@@ -1069,8 +1074,8 @@ body.rtl .info-icon {
                 .then(async data => {
                     const full = JSON.parse(await decrypt(data.data, key));
                     displayFullInfo({
-                        name: embedded.n,
-                        criticalInfo: embedded.c,
+                        name: currentName,
+                        criticalInfo: currentCriticalInfo,
                         publicInfo: full.publicInfo,
                         privateInfo: full.privateInfo
                     });
@@ -1109,9 +1114,39 @@ body.rtl .info-icon {
             displayEmergencyInfo(full);
         }
 
+        function buildUploadMessage() {
+            if (currentCreated) {
+                const ageMinutes = Math.floor((Date.now() - new Date(currentCreated).getTime()) / 60000);
+                return `⏳ Data still uploading... (${ageMinutes} min old, usually ready in 5-30 min)`;
+            }
+            return '⏳ Data still uploading... (usually ready in 5-30 min)';
+        }
+
         function addOfflineNotice() {
             const el = document.getElementById('loading-message');
-            if (el) el.textContent = 'Additional information requires internet';
+            if (el) el.textContent = buildUploadMessage();
+            if (!uploadCheckInterval) {
+                startUploadStatusPolling();
+            }
+        }
+
+        function startUploadStatusPolling() {
+            uploadCheckInterval = setInterval(async () => {
+                try {
+                    const full = await fetchFromArchive(currentGUID, currentKey);
+                    clearInterval(uploadCheckInterval);
+                    uploadCheckInterval = null;
+                    displayFullInfo({
+                        name: currentName,
+                        criticalInfo: currentCriticalInfo,
+                        publicInfo: full.publicInfo,
+                        privateInfo: full.privateInfo
+                    });
+                } catch (error) {
+                    const el = document.getElementById('loading-message');
+                    if (el) el.textContent = buildUploadMessage();
+                }
+            }, 10000);
         }
 
         function handleLegacyFormat(hash) {
@@ -1918,7 +1953,8 @@ body.rtl .info-icon {
                 // Only generate QR after successful upload
                 const embedded = btoa(JSON.stringify({
                     n: formData.name,
-                    c: formData.criticalInfo?.substring(0, 100)
+                    c: formData.criticalInfo?.substring(0, 100),
+                    t: created
                 }));
 
                 const qrUrl = `${VIEWER_URL}#v2:${currentGUID}:${currentKey}:${embedded}`;


### PR DESCRIPTION
## Summary
- track QR creation time and critical info in app state
- poll backup server when data not yet available and show upload ETA
- embed creation timestamp in generated QR codes for better status messages

## Testing
- `npx prettier --check index.html`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_68ade90373e483328f680e2e162533e4