### PR TITLE
Expand emergency layout width

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,12 +33,12 @@
 
         .container {
             width: calc(100vw - 40px) !important;
-            max-width: 500px !important;
+            max-width: 700px !important;
             margin: 20px auto !important;
             background: white;
             border-radius: 20px;
             box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
-            overflow: hidden;
+            overflow: visible;
             animation: slideIn 0.3s ease;
         }
 

--- a/text911.html
+++ b/text911.html
@@ -23,9 +23,9 @@
             background: white;
             border-radius: 20px;
             box-shadow: 0 20px 60px rgba(0,0,0,0.4);
-            max-width: 400px;
+            max-width: 700px;
             width: 100%;
-            overflow: hidden;
+            overflow: visible;
         }
         .header {
             background: linear-gradient(135deg, #991b1b 0%, #7f1d1d 100%);


### PR DESCRIPTION
## Summary
- widen emergency page containers to 700px for a less cramped layout
- allow overflowing content to remain visible to prevent bottom clipping

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adeec4d96083329bced7ae339c0150