### PR TITLE
Restore view after failed login

### DIFF
--- a/index.html
+++ b/index.html
@@ -1725,6 +1725,9 @@
             } catch (error) {
                 console.error('Update error:', error);
                 alert('Failed to prepare update: ' + error.message);
+                if (currentBlob) {
+                    displayFullInfo(currentBlob);
+                }
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Restore previously displayed data when owner login fails to avoid empty form

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adf86e937c8332aef0b5026bca6cca