### PR TITLE
Add zoom controls for text scaling

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -18,7 +18,7 @@
         
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
-            font-size: 11pt;
+            font-size: 0.9167rem;
             line-height: 1.5;
             color: #1e293b;
             background: white;
@@ -48,7 +48,7 @@
             padding: 4px 12px;
             border-radius: 4px;
             font-weight: 600;
-            font-size: 9pt;
+            font-size: 0.75rem;
             display: flex;
             align-items: center;
             gap: 6px;
@@ -76,13 +76,13 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            font-size: 11pt;
+            font-size: 0.9167rem;
             flex-shrink: 0;
         }
         
         .status-icon {
-            width: 14px;
-            height: 14px;
+            width: 0.875rem;
+            height: 0.875rem;
             border-radius: 50%;
             background: #22c55e;
             display: flex;
@@ -94,7 +94,7 @@
         .status-icon::after {
             content: "✓";
             color: white;
-            font-size: 9pt;
+            font-size: 0.75rem;
             font-weight: bold;
         }
         
@@ -111,7 +111,7 @@
             padding: 5px 12px;
             border: none;
             border-radius: 4px;
-            font-size: 9pt;
+            font-size: 0.75rem;
             cursor: pointer;
             transition: all 0.2s;
             white-space: nowrap;
@@ -202,7 +202,7 @@
             cursor: pointer;
             border-bottom: 3px solid transparent;
             transition: all 0.2s;
-            font-size: 10pt;
+            font-size: 0.8333rem;
             font-weight: 500;
             color: #64748b;
         }
@@ -230,13 +230,13 @@
         
         .header h1 {
             color: #3b82f6;
-            font-size: 24pt;
+            font-size: 2rem;
             margin-bottom: 5px;
         }
         
         .header p {
             color: #64748b;
-            font-size: 10pt;
+            font-size: 0.8333rem;
         }
         
         .last-updated {
@@ -287,7 +287,7 @@
         }
         
         .section-header h2 {
-            font-size: 16pt;
+            font-size: 1.3333rem;
             color: #1e293b;
             display: flex;
             align-items: center;
@@ -312,7 +312,7 @@
         label {
             display: block;
             font-weight: 600;
-            font-size: 10pt;
+            font-size: 0.8333rem;
             color: #334155;
             margin-bottom: 3px;
         }
@@ -334,7 +334,7 @@
             padding: 8px 10px;
             border: 1px solid #cbd5e1;
             border-radius: 4px;
-            font-size: 10pt;
+            font-size: 0.8333rem;
             background: white;
         }
         
@@ -367,7 +367,7 @@
             border-radius: 6px;
             padding: 12px;
             margin: 15px 0;
-            font-size: 9pt;
+            font-size: 0.75rem;
         }
         
         .warning-box {
@@ -376,7 +376,7 @@
             border-radius: 6px;
             padding: 12px;
             margin: 15px 0;
-            font-size: 9pt;
+            font-size: 0.75rem;
         }
         
         .danger-box {
@@ -385,7 +385,7 @@
             border-radius: 6px;
             padding: 15px;
             margin: 15px 0;
-            font-size: 10pt;
+            font-size: 0.8333rem;
             font-weight: 600;
             text-align: center;
         }
@@ -394,7 +394,7 @@
             display: inline-flex;
             align-items: center;
             gap: 5px;
-            font-size: 9pt;
+            font-size: 0.75rem;
             padding: 3px 8px;
             border-radius: 4px;
             margin-left: 10px;
@@ -477,7 +477,7 @@
             border: none;
             border-radius: 4px;
             padding: 4px 8px;
-            font-size: 9pt;
+            font-size: 0.75rem;
             cursor: pointer;
         }
         
@@ -491,7 +491,7 @@
             border: none;
             border-radius: 4px;
             padding: 6px 14px;
-            font-size: 9pt;
+            font-size: 0.75rem;
             cursor: pointer;
             margin: 10px 0;
         }
@@ -559,7 +559,7 @@
         }
         
         .modal-header h3 {
-            font-size: 18pt;
+            font-size: 1.5rem;
             color: #1e293b;
         }
         
@@ -616,7 +616,7 @@
             border: none;
             border-radius: 4px;
             padding: 8px 16px;
-            font-size: 10pt;
+            font-size: 0.8333rem;
             cursor: pointer;
             margin: 20px 0;
         }
@@ -639,7 +639,7 @@
         
         #lockTimer {
             margin-left: 8px;
-            font-size: 9pt;
+            font-size: 0.75rem;
             color: #94a3b8;
         }
         
@@ -676,7 +676,7 @@
         }
         
         h3 {
-            font-size: 13pt;
+            font-size: 1.0833rem;
             color: #1e293b;
             margin-bottom: 10px;
             padding-bottom: 5px;
@@ -685,7 +685,7 @@
         
         #lockTimer {
             margin-left: 10px;
-            font-size: 10pt;
+            font-size: 0.8333rem;
             color: #94a3b8;
         }
         
@@ -696,7 +696,7 @@
             color: white;
             border-radius: 4px;
             cursor: pointer;
-            font-size: 10pt;
+            font-size: 0.8333rem;
         }
         
         .file-input-label:hover {
@@ -710,16 +710,16 @@
             
             .btn {
                 padding: 4px 10px;
-                font-size: 9pt;
+                font-size: 0.75rem;
             }
             
             .save-status {
-                font-size: 8pt;
+                font-size: 0.6667rem;
                 padding: 3px 8px;
             }
             
             .security-status {
-                font-size: 10pt;
+                font-size: 0.8333rem;
             }
         }
         
@@ -779,7 +779,7 @@
             
             .tab {
                 padding: 10px 15px;
-                font-size: 9pt;
+                font-size: 0.75rem;
             }
         }
     </style>
@@ -838,7 +838,7 @@
                     <label>Confirm Password</label>
                     <input type="password" id="modalConfirmPassword" placeholder="Confirm password">
                 </div>
-                <p style="font-size: 9pt; color: #64748b; margin-top: 10px;">
+                <p style="font-size: 0.75rem; color: #64748b; margin-top: 10px;">
                     Use a strong password to protect your medical information. This password cannot be recovered if lost.
                     <br><strong>Note:</strong> Session auto-locks after 45 minutes of inactivity.
                 </p>
@@ -2857,7 +2857,7 @@
                     * { margin: 0; padding: 0; box-sizing: border-box; }
                     body {
                         font-family: Arial, sans-serif;
-                        font-size: 11pt;
+                        font-size: 0.9167rem;
                         line-height: 1.4;
                         color: #000;
                         padding: 0.5in;
@@ -2869,11 +2869,11 @@
                         border-bottom: 2px solid #000;
                     }
                     .pdf-header h1 {
-                        font-size: 18pt;
+                        font-size: 1.5rem;
                         margin-bottom: 5px;
                     }
                     .pdf-header p {
-                        font-size: 10pt;
+                        font-size: 0.8333rem;
                         color: #555;
                     }
                     .pdf-section {
@@ -2881,7 +2881,7 @@
                         page-break-inside: avoid;
                     }
                     .pdf-section-title {
-                        font-size: 14pt;
+                        font-size: 1.1667rem;
                         font-weight: bold;
                         background: #f0f0f0;
                         padding: 5px 10px;
@@ -2921,7 +2921,7 @@
                         width: 100%;
                         border-collapse: collapse;
                         margin-bottom: 10px;
-                        font-size: 10pt;
+                        font-size: 0.8333rem;
                     }
                     .pdf-table th {
                         background: #f0f0f0;
@@ -2950,7 +2950,7 @@
                     }
                     .pdf-subsection-title {
                         font-weight: bold;
-                        font-size: 12pt;
+                        font-size: 1rem;
                         margin-bottom: 5px;
                         text-decoration: underline;
                     }

--- a/index.html
+++ b/index.html
@@ -75,13 +75,13 @@
         }
         
         .header h1 {
-            font-size: 24px;
+            font-size: 1.5rem;
             margin-bottom: 5px;
         }
         
         .header p {
             opacity: 0.9;
-            font-size: 14px;
+            font-size: 0.875rem;
         }
         
         .content {
@@ -103,7 +103,7 @@
         }
 
         .info-header h2 {
-            font-size: 18px;
+            font-size: 1.125rem;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -128,7 +128,7 @@
         }
         
         .info-icon {
-            font-size: 20px;
+            font-size: 1.25rem;
             margin-right: 12px;
             flex-shrink: 0;
         }
@@ -138,14 +138,14 @@
         }
         
         .info-label {
-            font-size: 12px;
+            font-size: 0.75rem;
             color: #666;
             text-transform: uppercase;
             margin-bottom: 2px;
         }
         
         .info-value {
-            font-size: 16px;
+            font-size: 1rem;
             color: #2c3e50;
             font-weight: 500;
         }
@@ -180,7 +180,7 @@
         
         .private-section h3 {
             color: #856404;
-            font-size: 16px;
+            font-size: 1rem;
             margin-bottom: 10px;
             display: flex;
             align-items: center;
@@ -192,12 +192,12 @@
             padding: 10px;
             border: 2px solid #ffc107;
             border-radius: 8px;
-            font-size: 14px;
+            font-size: 0.875rem;
             margin-bottom: 10px;
         }
         
         .hint {
-            font-size: 12px;
+            font-size: 0.75rem;
             color: #856404;
             margin-bottom: 10px;
             font-style: italic;
@@ -213,7 +213,7 @@
             margin-bottom: 5px;
             color: #2c3e50;
             font-weight: 500;
-            font-size: 14px;
+            font-size: 0.875rem;
         }
         
         .form-group input,
@@ -223,7 +223,7 @@
             padding: 10px;
             border: 2px solid #e0e0e0;
             border-radius: 8px;
-            font-size: 14px;
+            font-size: 0.875rem;
             transition: border-color 0.3s;
         }
         
@@ -240,7 +240,7 @@
         }
         
         .section-title {
-            font-size: 16px;
+            font-size: 1rem;
             color: #2c3e50;
             margin: 25px 0 15px;
             padding-top: 20px;
@@ -261,7 +261,7 @@
             color: white;
             border: none;
             border-radius: 10px;
-            font-size: 16px;
+            font-size: 1rem;
             font-weight: 600;
             cursor: pointer;
             transition: all 0.3s;
@@ -334,7 +334,7 @@
         .help-link a {
             color: #667eea;
             text-decoration: none;
-            font-size: 14px;
+            font-size: 0.875rem;
         }
         
         .help-content {
@@ -342,7 +342,7 @@
             border-radius: 10px;
             padding: 15px;
             margin-top: 10px;
-            font-size: 14px;
+            font-size: 0.875rem;
             line-height: 1.6;
             display: none;
         }
@@ -423,18 +423,18 @@
         }
 
         .step-icon {
-            font-size: 48px;
+            font-size: 3rem;
             margin-bottom: 20px;
         }
 
         #step-title {
-            font-size: 24px;
+            font-size: 1.5rem;
             margin-bottom: 10px;
             font-weight: 600;
         }
 
         #step-message {
-            font-size: 16px;
+            font-size: 1rem;
             opacity: 0.9;
             line-height: 1.5;
         }
@@ -535,7 +535,7 @@
             padding: 10px;
             border-radius: 5px;
             font-family: monospace;
-            font-size: 12px;
+            font-size: 0.75rem;
             white-space: pre-wrap;
             word-break: break-all;
             max-height: 200px;
@@ -554,7 +554,7 @@
             }
             
             .header h1 {
-                font-size: 20px;
+                font-size: 1.25rem;
             }
             
             .action-buttons {
@@ -568,7 +568,7 @@
             border-radius: 8px;
             margin-top: 15px;
             text-align: center;
-            font-size: 14px;
+            font-size: 0.875rem;
         }
         
         .status-success {
@@ -649,7 +649,7 @@
         }
 
         .huge-number {
-            font-size: 12px;
+            font-size: 0.75rem;
             color: #666;
             word-break: break-all;
         }
@@ -700,7 +700,7 @@
             padding: 10px;
             background: #f8f9fa;
             border-radius: 8px;
-            font-size: 12px;
+            font-size: 0.75rem;
         }
 
         .final-reminder {
@@ -773,7 +773,7 @@
              padding: 6px 16px;
              font-weight: bold;
              cursor: pointer;
-             font-size: 14px;
+             font-size: 0.875rem;
              transition: all 0.3s;
          }
 
@@ -788,6 +788,11 @@
             gap: 10px;
         }
 
+        .size-controls {
+            display: flex;
+            gap: 4px;
+        }
+
         .lang-select {
             position: relative;
         }
@@ -798,7 +803,7 @@
             border-radius: 8px;
             padding: 6px 10px;
             cursor: pointer;
-            font-size: 14px;
+            font-size: 0.875rem;
             direction: ltr;
         }
 
@@ -808,7 +813,7 @@
             border-radius: 8px;
             padding: 6px 10px;
             cursor: pointer;
-            font-size: 14px;
+            font-size: 0.875rem;
         }
 
         .lang-dropdown {
@@ -845,7 +850,7 @@
             border: none;
             color: #667eea;
             cursor: pointer;
-            font-size: 14px;
+            font-size: 0.875rem;
         }
 
         .health-records-btn {
@@ -853,7 +858,7 @@
             border: none;
             color: #667eea;
             cursor: pointer;
-            font-size: 14px;
+            font-size: 0.875rem;
         }
 
           body.rtl {
@@ -878,11 +883,11 @@
         @media (max-width: 480px) {
             .lang-button {
                 padding: 4px 8px;
-                font-size: 12px;
+                font-size: 0.75rem;
             }
 
             .login-btn {
-                font-size: 12px;
+                font-size: 0.75rem;
             }
 
             .logo-text-full {
@@ -930,7 +935,7 @@
         .field-info {
             display: flex;
             justify-content: space-between;
-            font-size: 12px;
+            font-size: 0.75rem;
             color: #555;
             margin-top: 4px;
         }
@@ -945,9 +950,10 @@
             </button>
         </div>
         <div class="controls">
-            <button class="size-toggle" onclick="toggleTextSize()">
-                <span id="size-indicator">Aa</span>
-            </button>
+            <div class="size-controls">
+                <button class="size-toggle" onclick="changeTextSize(-1)">🔍-</button>
+                <button class="size-toggle" onclick="changeTextSize(1)">🔍+</button>
+            </div>
             <div class="lang-select">
                 <button class="lang-button" onclick="toggleLangDropdown()"><span id="current-language">EN</span> ▼</button>
                 <div class="lang-dropdown"></div>
@@ -1101,16 +1107,13 @@
           const sizes = { standard: '16px', large: '20px', xlarge: '24px' };
           const next = sizes[size] || sizes.standard;
           document.documentElement.style.fontSize = next;
-          const indicator = document.getElementById('size-indicator');
-          if (indicator) {
-            indicator.textContent = size === 'large' ? 'A+' : size === 'xlarge' ? 'A++' : 'Aa';
-          }
         }
 
-        function toggleTextSize() {
+        function changeTextSize(delta) {
           const order = ['standard', 'large', 'xlarge'];
           const current = localStorage.getItem('ikey_text_size') || 'standard';
-          const next = order[(order.indexOf(current) + 1) % order.length];
+          const nextIndex = Math.min(Math.max(order.indexOf(current) + delta, 0), order.length - 1);
+          const next = order[nextIndex];
           localStorage.setItem('ikey_text_size', next);
           applyTextSize(next);
         }
@@ -1938,7 +1941,7 @@
                     <div id="qr-result" style="display: none;">
                         <div class="qr-display">
                             <h3>✅ Your iKey Created</h3>
-                            <p style="color: #666; font-size: 14px; margin: 10px 0;">
+                            <p style="color: #666; font-size: 0.875rem; margin: 10px 0;">
                                 ✓ Encrypted with zero-knowledge security<br>
                                 ✓ Backed up to Archive.org<br>
                                 ✓ Only this QR can decrypt your data

--- a/text911.html
+++ b/text911.html
@@ -34,12 +34,12 @@
             text-align: center;
         }
         .header h1 {
-            font-size: 22px;
+            font-size: 1.375rem;
             font-weight: 700;
             margin-bottom: 4px;
         }
         .header p {
-            font-size: 13px;
+            font-size: 0.8125rem;
             opacity: 0.95;
         }
         .emergency-buttons {
@@ -79,13 +79,13 @@
             box-shadow: 0 8px 20px rgba(59, 130, 246, 0.4);
         }
         .btn-911 .icon {
-            font-size: 28px;
+            font-size: 1.75rem;
         }
         .btn-911 .label {
-            font-size: 16px;
+            font-size: 1rem;
         }
         .btn-911 .sublabel {
-            font-size: 10px;
+            font-size: 0.625rem;
             opacity: 0.9;
             font-weight: 500;
         }
@@ -104,7 +104,7 @@
             border: 2px solid #10b981;
         }
         .card-label {
-            font-size: 11px;
+            font-size: 0.6875rem;
             text-transform: uppercase;
             letter-spacing: 0.5px;
             color: #6b7280;
@@ -118,7 +118,7 @@
             font-weight: 600;
         }
         .card-value {
-            font-size: 15px;
+            font-size: 0.9375rem;
             font-weight: 600;
             color: #111827;
             word-break: break-word;
@@ -126,14 +126,14 @@
         }
         .card-value.mono {
             font-family: 'SF Mono', 'Courier New', monospace;
-            font-size: 16px;
+            font-size: 1rem;
             letter-spacing: 1px;
         }
         .status-badge {
             display: inline-block;
             padding: 3px 6px;
             border-radius: 4px;
-            font-size: 9px;
+            font-size: 0.5625rem;
             font-weight: 700;
             background: #10b981;
             color: white;
@@ -146,7 +146,7 @@
             color: #4b5563;
             border: 2px solid #d1d5db;
             border-radius: 10px;
-            font-size: 14px;
+            font-size: 0.875rem;
             font-weight: 600;
             cursor: pointer;
             transition: all 0.2s;
@@ -164,10 +164,10 @@
             border: 3px solid #fee2e2;
             border-top: 3px solid #dc2626;
             border-radius: 50%;
-            width: 48px;
-            height: 48px;
+            width: 3rem;
+            height: 3rem;
             animation: spin 1s linear infinite;
-            margin: 0 auto 16px;
+            margin: 0 auto 1rem;
         }
         @keyframes spin {
             0% { transform: rotate(0deg); }
@@ -210,7 +210,7 @@
             background: white;
             border-radius: 12px;
             padding: 20px;
-            font-size: 12px;
+            font-size: 0.75rem;
             line-height: 1.5;
             color: #374151;
             max-width: 300px;
@@ -225,7 +225,7 @@
             height: 24px;
             line-height: 24px;
             text-align: center;
-            font-size: 20px;
+            font-size: 1.25rem;
             cursor: pointer;
             color: #6b7280;
             border-radius: 50%;
@@ -235,7 +235,7 @@
             border-left: 3px solid #f59e0b;
             padding: 8px 12px;
             margin-top: 16px;
-            font-size: 11px;
+            font-size: 0.6875rem;
             color: #92400e;
             line-height: 1.4;
         }
@@ -243,7 +243,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            font-size: 12px;
+            font-size: 0.75rem;
             color: #6b7280;
             margin: 12px 0;
             padding: 8px;


### PR DESCRIPTION
## Summary
- Replace text size toggle with separate zoom out/in buttons using [🔍-] and [🔍+] icons
- Apply global text scaling via JavaScript `changeTextSize` and convert CSS font sizes to rem units
- Use rem-based dimensions for icons and spinner so they scale with text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adfc3aa4fc8332bdd932108c1aaea1