### PR TITLE
Fix EHR tab iframe height

### DIFF
--- a/index.html
+++ b/index.html
@@ -2825,8 +2825,14 @@
                 document.getElementById('qrTab').style.display = 'none';
                 document.getElementById('text911Tab').style.display = 'none';
                 const frame = document.getElementById('healthRecordsFrame');
+                frame.onload = () => {
+                    frame.style.height = frame.contentDocument.body.scrollHeight + 'px';
+                };
                 if (!frame.src) {
                     frame.src = 'health-records.html';
+                } else {
+                    // Ensure height is adjusted if the frame was already loaded
+                    frame.style.height = frame.contentDocument.body.scrollHeight + 'px';
                 }
                 document.getElementById('healthRecordsTab').style.display = 'block';
             } catch (e) {
@@ -2907,7 +2913,7 @@
     </script>
     </div>
     <div id="healthRecordsTab" style="display:none;">
-        <iframe id="healthRecordsFrame" style="border:none;width:100%;height:800px;"></iframe>
+        <iframe id="healthRecordsFrame" style="border:none;width:100%;"></iframe>
     </div>
     <div id="text911Tab" style="display:none;">
         <div class="container">


### PR DESCRIPTION
## Summary
- Dynamically resize health records iframe so full record displays within tab
- Remove fixed iframe height to expand with content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adfd49196483328c796ab9e6ef086b