### PR TITLE
Ensure health records display full width and preserve scroll

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -1929,6 +1929,8 @@
             }
             
             async performSave(password) {
+                const scrollPosition = window.scrollY;
+
                 const formData = this.collectFormData();
                 const timestamp = new Date().toLocaleString();
                 
@@ -1976,8 +1978,10 @@
                     }
                     
                     alert('File saved successfully with encryption');
+                    window.scrollTo(0, scrollPosition);
                 } catch (error) {
                     alert('Error encrypting data: ' + error.message);
+                    window.scrollTo(0, scrollPosition);
                 }
             }
             

--- a/index.html
+++ b/index.html
@@ -32,6 +32,10 @@
             padding-top: 80px !important;
         }
 
+        #healthRecordsTab {
+            width: 100%;
+        }
+
         .container {
             width: calc(100vw - 40px) !important;
             max-width: 700px !important;


### PR DESCRIPTION
## Summary
- Make health records tab span the full browser width
- Preserve the user's scroll position after saving data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adff4797f883328dbcd38d0b61174a