### PR TITLE
Center 911 button and prevent overlap on top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -744,9 +744,9 @@
             right: 0;
             height: 48px;
             background: white;
-            display: flex;
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
             align-items: center;
-            justify-content: space-between;
             padding: 0 10px;
             box-shadow: 0 2px 6px rgba(0,0,0,0.1);
             z-index: 1000;
@@ -757,6 +757,7 @@
             display: flex;
             align-items: center;
             gap: 6px;
+            justify-self: start;
         }
 
          .logo-text-short {
@@ -764,9 +765,7 @@
          }
 
          .center-911 {
-             position: absolute;
-             left: 50%;
-             transform: translateX(-50%);
+             justify-self: center;
          }
 
          .emergency-911-btn {
@@ -790,6 +789,7 @@
             display: flex;
             align-items: center;
             gap: 10px;
+            justify-self: end;
         }
 
         .size-controls {
@@ -879,9 +879,12 @@
               text-align: right;
         }
 
-        body.rtl .top-bar {
-            flex-direction: row-reverse;
-          }
+        body.rtl .logo {
+            justify-self: end;
+        }
+        body.rtl .controls {
+            justify-self: start;
+        }
 
           body.rtl .lang-dropdown {
               right: auto;


### PR DESCRIPTION
## Summary
- Reworked top bar layout using CSS grid so the 911 button is centered and no longer overlaps other controls.
- Added RTL-specific alignment rules to keep layout consistent in right-to-left languages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae007b6dec8332a541c494ed011a4c